### PR TITLE
display output as results become available

### DIFF
--- a/examples/circuitpython_kernel.ipynb
+++ b/examples/circuitpython_kernel.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using CircuitPython with Jupyter\n",
+    "\n",
+    "This project is a fork of [Adafruit's Jupyter kernel](https://learn.adafruit.com/circuitpython-with-jupyter-notebooks/) with a few enhancements (like reconnecting to the CP VM if the connection is lost). Until these changes have been incorportated in Adafruit's distribution use the instructions below instead of those on Adafruit's website."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Requires Python 3, then run the following commands from the command line:\n",
+    "\n",
+    "```\n",
+    "pip3 install cp_kernel\n",
+    "```\n",
+    "\n",
+    "Then run start [jupyter lab](https://jupyterlab.readthedocs.io) with \n",
+    "\n",
+    "```\n",
+    "jupyter lab\n",
+    "```\n",
+    "\n",
+    "A browser window opens with the Jupyer Lab GUI. The console windows displays verbose information that you can ignore except when you experience problems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CircuitPython Notebook\n",
+    "\n",
+    "Choose `File->New->Notebook` from the menu and select the `CircuitPython` kernel. Make sure a microcontroller board is connected to the computer via USB. The kernel finds the board automatically; check the console output in case of problems.\n",
+    "\n",
+    "Use the notebook as usual, except that now code in cells is uploaded to the board for evaluation with CircuitPython. \n",
+    "\n",
+    "Few differences:\n",
+    "\n",
+    "* No output is printed except that from explicit `print` statements\n",
+    "* The results from evaluation are displayed all at once, not incrementally during code execution\n",
+    "* Magic commands do not work, except those described below\n",
+    "\n",
+    "**Occasionally you may get syntax error messages for code that is clearly correct.** This is likely due to the microcontroller not being able to keep up with the code upload and occurs in particular with large cells. \n",
+    "\n",
+    "The solution is to add a delay between each line of code as it is being sent to the controller. Executing the cell below will set this delay to 0.1 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%upload_delay 0.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execute Python code as usual:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(3):\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Error messages are marked in the notebook output by coloring:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"<stdin>\", line 4, in <module>\n",
+      "IndexError: error demo\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(5):\n",
+    "    print(i)\n",
+    "    if i>3:\n",
+    "        raise IndexError(\"error demo\")\n",
+    "    \n",
+    "print(\"never gets here\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Longer calculations output results as they become available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n"
+     ]
+    }
+   ],
+   "source": [
+    "from time import sleep\n",
+    "\n",
+    "for i in range(5):\n",
+    "    print(i)\n",
+    "    sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with GPIO\n",
+    "\n",
+    "The code below blinks an led (change `LED1` to match your hardware). If you run this once, all works as expected, but if you execute the cell a second time you get an error:\n",
+    "\n",
+    "```\n",
+    "Traceback (most recent call last):\n",
+    "  File \"<stdin>\", line 7, in <module>\n",
+    "ValueError: LED1 in use\n",
+    "```\n",
+    "\n",
+    "To fix it, you can either deinit the led (and other resources your code is using) before running the cell, or, simpler, perform a soft reset `%softreset` as shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%softreset\n",
+    "\n",
+    "from board import LED1\n",
+    "from time import sleep\n",
+    "import digitalio\n",
+    "\n",
+    "led = digitalio.DigitalInOut(LED1)\n",
+    "led.direction = digitalio.Direction.OUTPUT\n",
+    "\n",
+    "led.switch_to_output(value=False, drive_mode=digitalio.DriveMode.PUSH_PULL)\n",
+    "\n",
+    "for i in range(10):\n",
+    "    led.value = not led.value\n",
+    "    sleep(0.3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CircuitPython",
+   "language": "python",
+   "name": "circuitpython"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "python",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "pygments_lexer": "python3",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Longer running cells (that print intermediate results) appear unresponsive since results are displayed only after everything has been received.

This PR changes the behavior: now results are shown as micropython outputs them. E.g.

```python
from time import sleep

for i in range(5):
    print(i)
    sleep(1)
```

outputs a number once a second.

I've added an example notebook for illustration.